### PR TITLE
Corrected issue with warped path placement at incorrect index

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -167,12 +167,12 @@ pub fn replace_paths(
         if path.starts_with('/') || path.starts_with("http://") || path.starts_with("https://") {
             continue;
         }
-        if let Some(path) =
+        if let Some(new_path) =
             generate_new_path(output_path, notebook_path, Path::new(&path))?.to_str()
         {
-            let left = &markdown[0..range.start()];
-            let right = &markdown[range.end()..markdown.len()];
-            markdown = format!("{left}{path}{right}");
+            let left = &markdown.chars().take(range.start()).collect::<String>();
+            let right = &markdown.chars().skip(range.end()).collect::<String>();
+            markdown = format!("{left}{new_path}{right}");
         }
     }
 


### PR DESCRIPTION
The issue stemmed from the encoding of certain characters requiring more than 8 bits. As a result, the splitting process did not account for this fact, leading to the insertion of the new path at the wrong location. Notably, characters such as 'ü' caused the split index to shift, resulting in the misplaced path.